### PR TITLE
bugfix: 대시보드 Timezone 고정(UTC)

### DIFF
--- a/app.py
+++ b/app.py
@@ -107,6 +107,8 @@ def dashboard():
     domain = request.args.get('domain')
     timezone = request.args.get('timezone', 'UTC')  # 시간대 파라미터 추가
 
+    timezone = 'UTC'
+
     if not domain:
         return redirect(url_for('login'))
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Hardcode the dashboard timezone to UTC, ignoring any timezone specified in request parameters.