### PR TITLE
bugfix: 대시보드 Timezone 고정(UTC)

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -22,7 +22,7 @@
     </script>
     <div class="dashboard-container">
         <div class="dashboard-header">
-            <h1>{{ site.domain }} {{ _('Free Dashboard') }}</h1>
+            <h1>{{ site.domain }} {{ _('Free Dashboard') }} (Timezone: UTC)</h1>
             <div class="chart-controls">
                 <button class="btn btn-secondary" onclick="changeView('week')">{{ _('Week') }}</button>
                 <button class="btn btn-secondary" onclick="changeView('month')">{{ _('Month') }}</button>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Display 'Timezone: UTC' in the dashboard header for clarity.